### PR TITLE
dot-reporter breaks when failure has no stack attribute

### DIFF
--- a/reporters/dot.js
+++ b/reporters/dot.js
@@ -64,7 +64,7 @@ var m = {
         process.stdout.write('\n\n');
         process.stdout.write(m.padding + 'Failure: ' + failure.fullTitle + '\n');
         process.stdout.write(m.padding + failure.err.message.red + '\n');
-        if(typeof(failer.err.stack) !== 'undefined') {
+        if(typeof(failure.err.stack) !== 'undefined') {
           process.stdout.write(m.padding + failure.err.stack.replace(/\n/g, '\n' + m.padding, 1) + '\n');
         }
       });

--- a/reporters/dot.js
+++ b/reporters/dot.js
@@ -64,7 +64,9 @@ var m = {
         process.stdout.write('\n\n');
         process.stdout.write(m.padding + 'Failure: ' + failure.fullTitle + '\n');
         process.stdout.write(m.padding + failure.err.message.red + '\n');
-        process.stdout.write(m.padding + failure.err.stack.replace(/\n/g, '\n' + m.padding, 1) + '\n');
+        if(typeof(failer.err.stack) !== 'undefined') {
+          process.stdout.write(m.padding + failure.err.stack.replace(/\n/g, '\n' + m.padding, 1) + '\n');
+        }
       });
     });
 


### PR DESCRIPTION
Not all failures seem to have a stack attribute which resulted in a dot-reporter error when trying to print it out.
In the xunit reporter this is already checked.
